### PR TITLE
When the DNS Lookup is unsuccessful with result "TRY_AGAIN = 2", a false negative result might occur

### DIFF
--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/locator/BdxlLocator.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/locator/BdxlLocator.java
@@ -148,15 +148,14 @@ public class BdxlLocator extends AbstractLocator {
             if (lookup.getResult () != Lookup.SUCCESSFUL) {
                 // HOST_NOT_FOUND = The host does not exist
                 // TYPE_NOT_FOUND = The host exists, but has no records associated with the queried type
-                // Since we already tried couple of times with TRY_AGAIN for TCP and UDP, now giving up ...
-                if(lookup.getResult() == Lookup.HOST_NOT_FOUND || lookup.getResult() == Lookup.TRY_AGAIN
-                        || lookup.getResult() == Lookup.TYPE_NOT_FOUND) {
-                    throw new NotFoundException(
-                            String.format("Identifier '%s' is not registered in SML.", participantIdentifier.toString()));
-                } else {
-                    // Attribute to UNRECOVERABLE error, repeating the lookup would not be helpful
-                    throw new LookupException(
-                            String.format("Error when looking up identifier '%s' in SML.", participantIdentifier.toString()));
+                // TRY_AGAIN = Since we already tried a couple of times with TRY_AGAIN for TCP and UDP, now giving up ...
+                switch (lookup.getResult ()) {
+                    case Lookup.HOST_NOT_FOUND:
+                    case Lookup.TYPE_NOT_FOUND:
+                        throw new NotFoundException(String.format("Identifier '%s' is not registered in SML.", participantIdentifier.getIdentifier()));
+                    case Lookup.TRY_AGAIN:
+                    default:
+                        throw new LookupException(String.format("Error when looking up identifier '%s' in SML. DNS-Lookup-Err: %s", participantIdentifier.getIdentifier(), lookup.getErrorString()));
                 }
             }
 

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/locator/BusdoxLocator.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/locator/BusdoxLocator.java
@@ -102,15 +102,14 @@ public class BusdoxLocator extends AbstractLocator {
             if (lookup.getResult () != Lookup.SUCCESSFUL) {
                 // HOST_NOT_FOUND = The host does not exist
                 // TYPE_NOT_FOUND = The host exists, but has no records associated with the queried type
-                // Since we already tried couple of times with TRY_AGAIN for TCP and UDP, now giving up ...
-                if(lookup.getResult() == Lookup.HOST_NOT_FOUND || lookup.getResult() == Lookup.TRY_AGAIN
-                        || lookup.getResult() == Lookup.TYPE_NOT_FOUND) {
-                    throw new NotFoundException(
-                            String.format("Identifier '%s' is not registered in SML.", participantIdentifier.getIdentifier()));
-                } else {
-                    // Attribute to UNRECOVERABLE error, repeating the lookup would not be helpful
-                    throw new LookupException(
-                            String.format("Error when looking up identifier '%s' in SML.", participantIdentifier.getIdentifier()));
+                // TRY_AGAIN = Since we already tried a couple of times with TRY_AGAIN for TCP and UDP, now giving up ...
+                switch (lookup.getResult ()) {
+                    case Lookup.HOST_NOT_FOUND:
+                    case Lookup.TYPE_NOT_FOUND:
+                        throw new NotFoundException(String.format("Identifier '%s' is not registered in SML.", participantIdentifier.getIdentifier()));
+                    case Lookup.TRY_AGAIN:
+                    default:
+                        throw new LookupException(String.format("Error when looking up identifier '%s' in SML. DNS-Lookup-Err: %s", participantIdentifier.getIdentifier(), lookup.getErrorString()));
                 }
             }
         } catch (TextParseException e) {


### PR DESCRIPTION
## Pull Request Description
When the DNS Lookup is unsuccessful(`BdxlLocator.class`, `BusdoxLocator.class`) with result `TRY_AGAIN = 2`, a Locator cannot throw `NotFoundException.class`, as the participant may be registered in PEPPOL, and we do not want false-negative results.

We (Logiq AS) made our own version of the vefa-peppol for Oxalis where we logged and looked for occurrences of false negatives.  We found that multiple times a day the lookup resulted in `TRY_AGAIN = 2` where the participant was actually registered in PEPPOL.

I have changed so that a `TRY_AGAIN = 2` unsuccessful lookup results in a LookupException, and have included the error string into the resulting exception message, `DNS-Lookup-Err: %`.

**Consequences of the change:**
- Users of will see an increase in LookupExceptions.
- Reduction in false-negative lookup results (NotFoundExceptions).
-  Anyone that does string matching of the LookupException exception message might need to alter their logic, as the returning exception message is changed.
   - _I can return the exception message back to the previous exception message if the risk is to high._

## Type of Pull Request

- [ ] New feature/Enhancement - non-breaking change which adds functionality
- [X] Bug fix 
- [ ] Breaking change (Require Major version change?)
