### PR TITLE
Fix equals method on simple identifiers

### DIFF
--- a/peppol-common/src/main/java/network/oxalis/vefa/peppol/common/model/AbstractSimpleIdentifier.java
+++ b/peppol-common/src/main/java/network/oxalis/vefa/peppol/common/model/AbstractSimpleIdentifier.java
@@ -46,7 +46,7 @@ public abstract class AbstractSimpleIdentifier implements SimpleIdentifier {
 
         AbstractSimpleIdentifier that = (AbstractSimpleIdentifier) o;
 
-        return value.equals(that.value);
+        return Objects.equals(value, that.value);
     }
 
     @Override


### PR DESCRIPTION
## Pull Request Description

Small PR to fix the equals method for simple identifiers (the value can be null but it's expected to not be null inside the equals method).

## Type of Pull Request

- [ ] New feature/Enhancement - non-breaking change which adds functionality
- [X] Bug fix 
- [ ] Breaking change (Require Major version change?)

## Type of Change

- [ ] OpenPeppol AS2/AS4 specification
- [ ] OpenPeppol Spring/Fall release 
- [X] Oxalis software change or enhancement
- [ ] CEF change

## Pull Request Checklist:

- [X] My code follows the style guidelines of this project
- [NA] I have commented my code, particularly in hard-to-understand areas. But did not added unnecessary annotation/comment say @author name etc
- [X] I have checked my code for variable and method name and corrected grammar/spelling mistakes if any
- [NA] I have made corresponding changes to the documentation where needed
- [NA] My changes generate no new/additional warnings
- [X] My change is not breaking or creating conflict with associated dependencies 
- [X] I have performed a self-review of my own code
- [NA] I ran `mvn clean install` before commit and all tests run successfully 
- [NA] I conducted basic QA to assure all features are working fine
- [NA] My pull request generate no conflicts with `master` branch
- [NA] I requested code review from other team members
