### PR TITLE
Upgraded to Jakarta Servlet API

### DIFF
--- a/peppol-publisher/pom.xml
+++ b/peppol-publisher/pom.xml
@@ -130,8 +130,8 @@
 
         <!-- Java -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/peppol-publisher/src/main/java/network/oxalis/vefa/peppol/publisher/PublisherService.java
+++ b/peppol-publisher/src/main/java/network/oxalis/vefa/peppol/publisher/PublisherService.java
@@ -30,7 +30,7 @@ import network.oxalis.vefa.peppol.publisher.lang.PublisherException;
 import network.oxalis.vefa.peppol.security.xmldsig.DomUtils;
 import org.w3c.dom.Document;
 
-import javax.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServlet;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import java.io.OutputStream;

--- a/peppol-publisher/src/main/java/network/oxalis/vefa/peppol/publisher/servlet/PublisherServlet.java
+++ b/peppol-publisher/src/main/java/network/oxalis/vefa/peppol/publisher/servlet/PublisherServlet.java
@@ -28,9 +28,9 @@ import network.oxalis.vefa.peppol.publisher.PublisherService;
 import network.oxalis.vefa.peppol.publisher.lang.PublisherException;
 import network.oxalis.vefa.peppol.publisher.lang.NotFoundException;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.xml.bind.JAXBException;
 import java.io.IOException;
 import java.net.URI;

--- a/peppol-publisher/src/test/java/network/oxalis/vefa/peppol/publisher/servlet/PublisherServletTest.java
+++ b/peppol-publisher/src/test/java/network/oxalis/vefa/peppol/publisher/servlet/PublisherServletTest.java
@@ -8,8 +8,8 @@ import org.mockito.Mockito;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.xml.bind.JAXBException;
 import java.io.OutputStream;
 import java.net.URI;

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <guava.version>33.4.0-jre</guava.version>
         <typesafe-config.version>1.4.3</typesafe-config.version>
         <javax-mail.version>1.4.7</javax-mail.version>
-        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
+        <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <wiremock.version>2.27.2</wiremock.version>
@@ -229,9 +229,9 @@
                 <version>${javax-mail.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${javax.servlet-api.version}</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet-api.version}</version>
             </dependency>
 
             <!-- SLF4J -->


### PR DESCRIPTION
## Pull Request Description

This PR updates peppol-publisher module to Jakarta Servlet API.

The peppol-publisher module is probably little or never used by regular Oxalis users, so the module had not been updated from javax to jakarta along with the other modules earlier on.

Software that uses the old versjon of this module and relies on old javax servlet api needs to be updated.

## Type of Pull Request

- [x] New feature/Enhancement - non-breaking change which adds functionality
- [ ] Bug fix 
- [ ] Breaking change (Require Major version change?)

## Type of Change

- [ ] OpenPeppol AS2/AS4 specification
- [ ] OpenPeppol Spring/Fall release 
- [x] Oxalis software change or enhancement
- [ ] CEF change

## Pull Request Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas. But did not added unnecessary annotation/comment say @author name etc
- [x] I have checked my code for variable and method name and corrected grammar/spelling mistakes if any
- [x] I have made corresponding changes to the documentation where needed
- [x] My changes generate no new/additional warnings
- [x] My change is not breaking or creating conflict with associated dependencies 
- [x] I have performed a self-review of my own code
- [x] I ran `mvn clean install` before commit and all tests run successfully 
- [x] I conducted basic QA to assure all features are working fine
- [x] My pull request generate no conflicts with `master` branch
- [x] I requested code review from other team members
